### PR TITLE
Fixed documentation url, bumped version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spaceapi-server"
-version = "0.1.0"
-documentation = "https://coredump-ch.github.io/rust-docs/spaceapi-server/spaceapi-server/index.html"
+version = "0.1.1"
+documentation = "https://coredump-ch.github.io/rust-docs/spaceapi-server/spaceapi_server/index.html"
 repository = "https://github.com/coredump-ch/spaceapi-server-rs"
 license = "MIT"
 authors = [


### PR DESCRIPTION
See coredump-ch/spaceapi#70