### PR TITLE
Return HttpResult<Listening> from serve()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Possible log types:
 ### UNRELEASED
 
 - [changed] Removed datastore module, use Redis directly (#10)
+- [changed] SpaceapiServer.serve() now returns a HttpResult<Listening> (#16)
 - [added] Support status modifiers (#8)
 
 ### v0.1.1 (2015-11-16)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ include = [
 redis = "^0.5"
 rustc-serialize = "^0.3"
 iron = "^0.2"
+hyper = "^0.7"
 log = "^0.3"
 urlencoded = "^0.2"
 router = "^0.0.15"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,15 @@
 #[macro_use] extern crate error_type;
 extern crate rustc_serialize;
 extern crate iron;
+extern crate hyper;
 #[macro_use] extern crate router;
 extern crate urlencoded;
 extern crate redis;
 extern crate spaceapi;
 
 pub use spaceapi as api;
+pub use iron::error::HttpResult;
+pub use hyper::server::Listening;
 
 mod server;
 mod errors;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -61,15 +61,17 @@ impl SpaceapiServer {
 
     /// Start a HTTP server listening on ``self.host:self.port``.
     ///
-    /// This call is blocking. It can be interrupted with SIGINT (Ctrl+C).
-    pub fn serve(self) {
+    /// The call returns an `HttpResult<Listening>` object, see
+    /// http://ironframework.io/doc/hyper/server/struct.Listening.html
+    /// for more information.
+    pub fn serve(self) -> ::HttpResult<::Listening> {
         let host = self.host;
         let port = self.port;
 
         let router = self.route();
 
         println!("Starting HTTP server on http://{}:{}...", host, port);
-        Iron::new(router).http((host, port)).unwrap();
+        Iron::new(router).http((host, port))
     }
 
     /// Register a new sensor.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,70 @@
+extern crate spaceapi_server;
+
+use std::net::Ipv4Addr;
+use std::net::TcpStream;
+use std::io::ErrorKind;
+
+use spaceapi_server::SpaceapiServer;
+use spaceapi_server::api;
+use spaceapi_server::api::optional::Optional;
+
+
+/// Create a new status object containing test data.
+fn get_status() -> api::Status {
+    api::Status::new(
+        "ourspace",
+        "https://example.com/logo.png",
+        "https://example.com/",
+        api::Location {
+            address: Optional::Value("Street 1, Zürich, Switzerland".into()),
+            lat: 47.123,
+            lon: 8.88,
+        },
+        api::Contact {
+            irc: Optional::Absent,
+            twitter: Optional::Absent,
+            foursquare: Optional::Absent,
+            email: Optional::Value("hi@example.com".into()),
+        },
+        vec![
+            "email".into(),
+            "twitter".into(),
+        ],
+    )
+}
+
+
+/// Create a new SpaceapiServer instance listening on the specified port.
+fn get_server(ip: Ipv4Addr, port: u16, status: api::Status) -> SpaceapiServer {
+    // Start and return a server instance
+    SpaceapiServer::new(ip, port, status, "redis://127.0.0.1/", vec![]).unwrap()
+}
+
+
+#[test]
+fn server_starts() {
+    //! Test that the spaceapi server starts at all.
+
+    // Ip / port for test server
+    let ip = Ipv4Addr::new(127, 0, 0, 1);
+    let port = 3344;
+
+    // Test data
+    let status = get_status();
+
+    // Connection to port should fail right now
+    let connect_result = TcpStream::connect((ip, port));
+    assert!(connect_result.is_err());
+    assert_eq!(connect_result.unwrap_err().kind(), ErrorKind::ConnectionRefused);
+
+    // Instantiate and start server
+    let server = get_server(ip, port, status);
+    let mut listening = server.serve().unwrap();
+
+    // Connecting to server should work now
+    let connect_result = TcpStream::connect((ip, port));
+    assert!(connect_result.is_ok());
+
+    // Close server
+    listening.close().unwrap();
+}


### PR DESCRIPTION
This can be used to stop the server again, by calling the `close()`
method on the `Listening` instance.

Because Iron doesn't re-publish the `Listening` type, we need to add
Hyper as a dependency. See https://github.com/iron/iron/issues/406.

This change allows us to add integration tests that test the server
output.