### PR TITLE
Use ToSocketAddrs instead of IP port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Possible log types:
 - [changed] Removed datastore module, use Redis directly (#10)
 - [changed] SpaceapiServer.serve() now returns a HttpResult<Listening> (#16)
 - [added] Support status modifiers (#8)
+- [changed] Use `ToSocketAddrs` instead of `IPv4addr` and port in `SpaceapiServer::new()` (#22)
 
 ### v0.1.1 (2015-11-16)
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,8 @@
 //! https://github.com/DanielKeep/rust-error-type/issues/2.
 
 use redis::RedisError;
+use std::io;
+use std::borrow::Cow;
 
 
 /// A ``SpaceapiServerError`` wraps general problems that can occur in the SpaceAPI server.
@@ -12,6 +14,14 @@ error_type! {
     pub enum SpaceapiServerError {
         Redis(RedisError) {
             cause;
-        }
+        },
+        IoError(io::Error) {
+            cause;
+        },
+        Message(Cow<'static, str>) {
+            desc (e) &**e;
+            from (s: &'static str) s.into();
+            from (s: String) s.into();
+        },
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -37,7 +37,7 @@ fn get_status() -> api::Status {
 /// Create a new SpaceapiServer instance listening on the specified port.
 fn get_server(ip: Ipv4Addr, port: u16, status: api::Status) -> SpaceapiServer {
     // Start and return a server instance
-    SpaceapiServer::new(ip, port, status, "redis://127.0.0.1/", vec![]).unwrap()
+    SpaceapiServer::new((ip, port), status, "redis://127.0.0.1/", vec![]).unwrap()
 }
 
 


### PR DESCRIPTION
This is much more flexible than allowing just Ipv4Addr and a port.
Since it changes the constructor it's a breaking change.
-  [x] Update changelog