### PR TITLE
Initialize router without macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate rustc_serialize;
 extern crate iron;
 extern crate hyper;
-#[macro_use] extern crate router;
+extern crate router;
 extern crate urlencoded;
 extern crate redis;
 extern crate spaceapi;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -52,11 +52,18 @@ impl SpaceapiServer {
             })
         }
 
+    /// Create and return a Router instance.
     fn route(self) -> Router {
-        router!(
-            get "/" => handlers::ReadHandler::new(self.status.clone(), self.redis_connection_info.clone(), self.sensor_specs.clone(), self.status_modifiers),
-            put "/sensors/:sensor/" => handlers::UpdateHandler::new(self.redis_connection_info.clone(), self.sensor_specs.clone())
-        )
+        let mut router = Router::new();
+
+        router.get("/", handlers::ReadHandler::new(
+            self.status.clone(), self.redis_connection_info.clone(),
+            self.sensor_specs.clone(), self.status_modifiers));
+
+        router.put("/sensors/:sensor/", handlers::UpdateHandler::new(
+            self.redis_connection_info.clone(), self.sensor_specs.clone()));
+
+        router
     }
 
     /// Start a HTTP server listening on ``self.host:self.port``.


### PR DESCRIPTION
I don't think the macro creates any added value, besides one less mut variable.

This would also solve #19.