### PR TITLE
Remove unused import

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,7 +10,6 @@ use redis::{IntoConnectionInfo, ConnectionInfo};
 mod handlers;
 
 use ::api;
-use ::api::SensorTemplate;
 
 use ::sensors;
 use ::modifiers;


### PR DESCRIPTION
Fixes warning:
```
src/server/mod.rs:13:5: 13:26 warning: unused import, #[warn(unused_imports)] on by default
src/server/mod.rs:13 use ::api::SensorTemplate;
                         ^~~~~~~~~~~~~~~~~~~~~
```