### PR TITLE
Pub-export spaceapi crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ extern crate hyper;
 extern crate router;
 extern crate urlencoded;
 extern crate redis;
-extern crate spaceapi;
+pub extern crate spaceapi;
 
 pub use spaceapi as api;
 pub use iron::error::HttpResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,8 @@ extern crate hyper;
 extern crate router;
 extern crate urlencoded;
 extern crate redis;
-pub extern crate spaceapi;
+pub extern crate spaceapi as api;
 
-pub use spaceapi as api;
 pub use iron::error::HttpResult;
 pub use hyper::server::Listening;
 


### PR DESCRIPTION
Rust 1.9 shows the following warning:

    src/lib.rs:18:9: 18:24 warning: extern crate `spaceapi` is private, and cannot be reexported (error E0364), consider declaring with `pub`, #[warn(private_in_public)] on by default
    src/lib.rs:18 pub use spaceapi as api;
                          ^~~~~~~~~~~~~~~
    src/lib.rs:18:9: 18:24 warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    src/lib.rs:18:9: 18:24 note: for more information, see the explanation for E0446 (`--explain E0446`)