### PR TITLE
Log redis connection info when starting server

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -71,12 +71,13 @@ impl SpaceapiServer {
     /// http://ironframework.io/doc/hyper/server/struct.Listening.html
     /// for more information.
     pub fn serve(self) -> ::HttpResult<::Listening> {
-        let socket_addr = self.socket_addr;
-        let redis_connection_info = self.redis_connection_info.clone();
-        let router = self.route();
+        // Log some useful debug information
+        debug!("Redis connection info: {:?}", &self.redis_connection_info);
 
+        // Launch server process
+        let socket_addr = self.socket_addr;
+        let router = self.route();
         println!("Starting HTTP server on http://{}...", socket_addr);
-        debug!("Redis connection info: {:?}", &redis_connection_info);
         Iron::new(router).http(socket_addr)
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -72,9 +72,11 @@ impl SpaceapiServer {
     /// for more information.
     pub fn serve(self) -> ::HttpResult<::Listening> {
         let socket_addr = self.socket_addr;
+        let redis_connection_info = self.redis_connection_info.clone();
         let router = self.route();
 
         println!("Starting HTTP server on http://{}...", socket_addr);
+        debug!("Redis connection info: {:?}", &redis_connection_info);
         Iron::new(router).http(socket_addr)
     }
 


### PR DESCRIPTION
This will help us to debug problems like coredump-ch/status#98 in the future.