### PR TITLE
Integrate connection pooling for redis with r2d2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Possible log types:
 
 ### UNRELEASED
 
+- [changed] Introduced internal Redis connection pooling (#42)
 - ...
 
 ### v0.2.0 (2016-03-14)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ include = [
 ]
 
 [dependencies]
+r2d2 = "^0.7"
+# TODO: https://github.com/sorccu/r2d2-redis/pull/8
+r2d2_redis = { git = "https://github.com/dbrgn/r2d2-redis", rev = "unwrap" }
 redis = "^0.5"
 rustc-serialize = "^0.3"
 iron = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ include = [
 
 [dependencies]
 r2d2 = "^0.7"
-# TODO: https://github.com/sorccu/r2d2-redis/pull/8
-r2d2_redis = { git = "https://github.com/dbrgn/r2d2-redis", rev = "unwrap" }
+r2d2_redis = "^0.3.1"
 redis = "^0.5"
 rustc-serialize = "^0.3"
 iron = "^0.3"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@
 //! https://github.com/DanielKeep/rust-error-type/issues/2.
 
 use redis::RedisError;
+use r2d2::InitializationError;
 use std::io;
 use std::borrow::Cow;
 
@@ -13,6 +14,9 @@ error_type! {
     #[derive(Debug)]
     pub enum SpaceapiServerError {
         Redis(RedisError) {
+            cause;
+        },
+        R2d2(InitializationError) {
             cause;
         },
         IoError(io::Error) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ extern crate iron;
 extern crate hyper;
 extern crate router;
 extern crate urlencoded;
+extern crate r2d2;
+extern crate r2d2_redis;
 extern crate redis;
 pub extern crate spaceapi as api;
 
@@ -20,6 +22,7 @@ pub use hyper::server::Listening;
 
 mod server;
 mod errors;
+mod types;
 pub mod sensors;
 pub mod modifiers;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,6 @@
+//! Type definitions.
+
+use r2d2;
+use r2d2_redis::RedisConnectionManager;
+
+pub type RedisPool = r2d2::Pool<RedisConnectionManager>;


### PR DESCRIPTION
This is pretty cool :) It gives us a connection pool with 1 to 6 active Redis connections.

We need to depend on a git fork of the r2d2-redis library until [this PR](https://github.com/sorccu/r2d2-redis/pull/8) is merged and released.

If the database dies while the server process is started, the error is handled gracefully (regular output without sensors) + logged.

If all connections are blocked for longer than 1 second (see connection timeout in configuration), the same thing would happen. This means that sensors are not always contained in the response if the database server or the network is overloaded, but I think that's better than slowing down the entire API response for >1 second if a database server is down or overloaded. We could increase the timeout though, if you think it should be higher. The r2d2 default is 30 seconds IIRC.

Fixes #13.