### PR TITLE
Bump redis and r2d2_redis dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ include = [
 
 [dependencies]
 r2d2 = "^0.7"
-r2d2_redis = "^0.3.1"
-redis = "^0.5"
+r2d2_redis = "^0.4"
+redis = "^0.6"
 rustc-serialize = "^0.3"
 iron = "^0.3"
 hyper = "^0.8"


### PR DESCRIPTION
I don't think we expose any part of r2d2 / redis to the user, so this is not a breaking change.