### PR TITLE
Fix nightly build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,6 @@ spaceapi = "^0.1"
 
 [dev-dependencies]
 env_logger = "^0.3"
+
+[features]
+nightly = ["unstable"]


### PR DESCRIPTION
Addresses:
```
error: Package `spaceapi-server v0.2.1-dev (file:///home/travis/build/coredump-ch/spaceapi-server-rs)` does not have these features: `unstable`
```