### PR TITLE
Version information in API output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Possible log types:
 
 - [changed] Introduced internal Redis connection pooling (#42)
 - [changed] Updated spaceapi dependency to 0.3 (#46)
+- [added] Top level `get_version` function (#4)
 
 ### v0.2.0 (2016-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Possible log types:
 - [changed] Introduced internal Redis connection pooling (#42)
 - [changed] Updated spaceapi dependency to 0.3 (#46)
 - [added] Top level `get_version` function (#4)
+- [added] Add `LibraryVersions` status modifier (#4)
 
 ### v0.2.0 (2016-03-14)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spaceapi-server"
-version = "0.3.0-dev"
+version = "0.3.0"
 documentation = "https://coredump-ch.github.io/spaceapi-server-rs/"
 repository = "https://github.com/coredump-ch/spaceapi-server-rs"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ log = "^0.3"
 urlencoded = "^0.3"
 router = "^0.1"
 error-type = "^0.1"
-spaceapi = "^0.3"
+spaceapi = "^0.3.1"
 clippy = {version = "*", optional = true}
 
 [features]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,6 +3,7 @@ extern crate spaceapi_server;
 use spaceapi_server::SpaceapiServer;
 use spaceapi_server::api;
 use spaceapi_server::api::Optional::{Value, Absent};
+use spaceapi_server::modifiers;
 
 
 fn main() {
@@ -41,7 +42,9 @@ fn main() {
     // Set up server
     let listen = "127.0.0.1:8000";
     let redis = "redis://127.0.0.1/";
-    let modifiers = Vec::new();
+    let modifiers: Vec<Box<modifiers::StatusModifier + 'static>> = vec![
+        Box::new(modifiers::LibraryVersions),
+    ];
     let server = SpaceapiServer::new(listen, status, redis, modifiers);
 
     // Serve!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,19 @@ pub mod modifiers;
 
 pub use server::SpaceapiServer;
 pub use errors::SpaceapiServerError;
+
+/// Return own crate version. Used in API responses.
+pub fn get_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[cfg(test)]
+mod test {
+    use super::get_version;
+
+    #[test]
+    fn test_get_version() {
+        let version = get_version();
+        assert_eq!(3, version.split('.').count());
+    }
+}


### PR DESCRIPTION
This will fix #4.

But https://github.com/coredump-ch/spaceapi-rs/pull/31 will need to be merged and published first.

![screenshot](http://tmp.dbrgn.ch/screenshots/20160804003211-qv5lp5ul.png)