### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Possible log types:
 
 - [added] Top level `get_version` function (#4)
 - [added] Add `LibraryVersions` status modifier (#4)
-- [changed] Introduced internal Redis connection pooling (#42)
+- [changed] Introduced internal Redis connection pooling (#43)
 - [changed] Updated spaceapi dependency to 0.3 (#46)
 - [changed] Updated hyper dependency to 0.9 (#51)
 - [changed] Updated iron dependency to 0.4 (#51)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
-### v0.3.0 UNRELEASED
+### v0.X.X UNRELEASED
 
-- [changed] Introduced internal Redis connection pooling (#42)
-- [changed] Updated spaceapi dependency to 0.3 (#46)
+- ...
+
+### v0.3.0 (2016-09-01)
+
 - [added] Top level `get_version` function (#4)
 - [added] Add `LibraryVersions` status modifier (#4)
+- [changed] Introduced internal Redis connection pooling (#42)
+- [changed] Updated spaceapi dependency to 0.3 (#46)
 - [changed] Updated hyper dependency to 0.9 (#51)
 - [changed] Updated iron dependency to 0.4 (#51)
 


### PR DESCRIPTION
Update CHANGELOG.

The version number will stay at 0.3.0 until the next release. No more pre-release version bumping as discussed on Telegram.