### PR TITLE
Specify clippy version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ urlencoded = "^0.4"
 router = "^0.2"
 error-type = "^0.1"
 spaceapi = "^0.3.1"
-clippy = {version = "*", optional = true}
+clippy = {version = "^0.0.87", optional = true}
 
 [features]
 unstable = ["clippy"]


### PR DESCRIPTION
We can't actually release 0.3.0 because Cargo.toml contains a star dependency version specifier :dizzy_face: 

I propose to merge this and #54, and then to release 0.3.1.