### PR TITLE
Improve travis CI build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 matrix:
   allow_failures:
     - rust: nightly
+  fast_finish: true
 services:
   - redis-server
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ script:
       travis-cargo --only stable doc
 after_success:
   - travis-cargo --only stable doc-upload
-  - travis-cargo coveralls --no-sudo --verify
 env:
   global:
     - secure: Ss/dJ+hq4i0k72mntBSHkvSvNgyfL1/quVxdc9p8zXpT/7OXvEFf4wqeLBmP/kJvyn7I2qPOME6D2FxmNrw/jrosQ7OSgjw85ohzUXOST6+hn+N18Q3juWy3SlWxiWa7UpaAFP+VJjvuYeWC0tu7+N8v5JR3uMy0MIHW+FZWzicXnF7ANy4Lj9vW7pkQPUXKUI5hSU7/kNdPlFfecxqTGJifBxLLseeB6o6Wi5G/OxS2jTWVRcr9ztRIGM8odoU7HAvWqIu/HEQu/c5/q7MfwIXUnYsUYxNBDvr+cQHiTfIqeA+9mMMlKCPxHTVOBvmX4GXKX3BF1dTfkt2kRxYD1wttQVH+WgXHLRxlEsWB7H6v9r8FgYb2mIOi9c51X5uH2/5FMPNYIOVuy/mqmi0PX0sP9nbwpFUIvg8H3rwL9/y+meKUrsdntdSHHa+WkGNj+hXdTv/JWPefvHZivFU+/nr9rtH+AXhbU9MsgAqAPzB7bt1P2tnvQ3wnmay0hRqcW4g2aF1+q+1jT0m1ubQGeDgF20BC/YW66MjeGaGQwzm68LHc9b5dcQE+OuDB00JyPUqsqG3gVQwIPsjr/xWiZh//g0YTaqjMa/1yVu2qd8fHfSkENYXDRlX2SPXU5YAuzohJNDVPi9XU/Gkod8IhYJ5JzaLezy4twesh/Okqltk=


### PR DESCRIPTION
Disable coverall because it is horribly slow (bacause it compiles kcov from scratch...) and we don't really use the results.